### PR TITLE
Was not working with  xmlns:dct="http://purl.org/dc/terms/" attributes. 

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -99,9 +99,9 @@ while (n) {
 							attribute = "";
 							value = "";
 							
-							if (n.getAttribute(attr_names[i]).indexOf(":") == 2) {
+							if (n.getAttribute(attr_names[i]).indexOf(":") >0) {
 							
-								attribute = n.getAttribute(attr_names[i]).substring(3);
+								attribute = n.getAttribute(attr_names[i]).replace(/^\w{2,3}:/,'');
 								
 							}
 							
@@ -136,7 +136,7 @@ while (n) {
 								
 								if (attribute == "") {
 								
-									if(n.getAttribute("property")=="cc:attributionName"&&n.getAttribute("rel")=="cc:attributionURL"){
+									if(n.getAttribute("property")=="cc:attributionName"&&n.getAttribute("rel").indexOf("cc:attributionURL") != -1){
 										
 										attribute = n.getAttribute(attr_names[i]);
 										triple_array = Array(asset, "cc:attributionName", n.innerHTML);


### PR DESCRIPTION
Didn't work with three letter prefixes (eg xmlns:dct="http://purl.org/dc/terms/")
AND
As per http://labs.creativecommons.org/2011/ccrel-guide/#Images, rel can be something like rel="cc:attributionURL dct:creator" whereas the extension was checking for exactly rel="cc:attributionURL"

This is the page testing with... 
http://www.geograph.org.uk/photo/1107922
